### PR TITLE
Expose Debug port, update change logs

### DIFF
--- a/terra-node-base/CHANGELOG.md
+++ b/terra-node-base/CHANGELOG.md
@@ -6,4 +6,8 @@
 
 ----------
 
+## 1.0 - (June 3, 2020)
+
+----------
+
 * Migrated docker image from terra-toolkit.

--- a/terra-node-ci/CHANGELOG.md
+++ b/terra-node-ci/CHANGELOG.md
@@ -6,4 +6,8 @@
 
 ----------
 
+## 1.0 - (June 3, 2020)
+
+----------
+
 * Migrated docker image from terra-toolkit.

--- a/terra-node-dev/CHANGELOG.md
+++ b/terra-node-dev/CHANGELOG.md
@@ -6,9 +6,21 @@
 
 ----------
 
+## 1.1 - (June 16, 2020)
+
+----------
+
+### Changed
+
+* Exposed 9229 port for debugging
+
+## 1.0 - (June 3, 2020)
+
+----------
+
 * Migrated docker image from terra-toolkit.
 
-## Changed
+### Changed
 
 * Update the history file location to allow us to cache it between runs in a docker compose volume.
 * Add a custom zsh theme to distinguish when running the development container.

--- a/terra-node-dev/Dockerfile
+++ b/terra-node-dev/Dockerfile
@@ -2,6 +2,9 @@
 # This image copies no code in and can be used directly with a volume mount to add code to the /opt/module directory.
 FROM cerner/terra-node-base:latest
 
+# Open up port 9229 for node debugging
+EXPOSE 9229
+
 # Install zsh / oh-my-zsh
 RUN apk add zsh curl wget \
   && wget https://github.com/robbyrussell/oh-my-zsh/raw/master/tools/install.sh -O - | zsh || true\


### PR DESCRIPTION
# Summary

To attach a debugger to a node process port 9229 is used by default. To access that port from the docker container I've exposed it for the dev container.

## Additional Details
I went back and updated all the change logs. Since this is released on merge to master we never really have un-released changes.

@cerner/terra
<!-- If you haven't done so already, please...

1. Assign yourself to the PR.
2. Add the appropriate labels
3. Add your name to the [CONTRIBUTORS.md] file. Adding your name to the [CONTRIBUTORS.md] file signifies agreement to all rights and reservations provided by the [License].

Thanks for contributing to Terra! -->

[CONTRIBUTORS.md]: ../blob/master/CONTRIBUTORS.md
[License]: ../blob/master/LICENSE
